### PR TITLE
[Provider] - add position update

### DIFF
--- a/app/(tabs)/explore.tsx
+++ b/app/(tabs)/explore.tsx
@@ -59,6 +59,7 @@ export default function MapScreen() {
       const positionProvider = await createPositionProvider();
       if (positionProvider) {
         MapsIndoors.setPositionProvider(positionProvider);
+        positionProvider.start();
 
         positionProvider.addOnPositionUpdateListener(
           ({ point }: MPPositionResultInterface) => {

--- a/helpers/ExpoPositionProvider.ts
+++ b/helpers/ExpoPositionProvider.ts
@@ -14,6 +14,8 @@ class ExpoPositionProvider implements MPPositionProviderInterface {
 
   latestPosition?: MPPositionResultInterface;
 
+  timer?: NodeJS.Timeout;
+
   constructor() {
     this.updatePosition();
   }
@@ -48,6 +50,18 @@ class ExpoPositionProvider implements MPPositionProviderInterface {
     this.positionUpdateListeners.forEach((listener) => {
       if (this.latestPosition) listener(this.latestPosition);
     });
+  }
+
+  start() {
+    if (!this.timer) {
+      this.timer = setInterval(() => this.updatePosition(), 5000);
+    }
+  }
+
+  stop() {
+    if (this.timer) {
+      clearInterval(this.timer);
+    }
   }
 }
 


### PR DESCRIPTION
Le code du sdk register un listener (en plus de celui que tu register toi-meme), et c'est cet élément qui va envoyer la position à la partie native du SDK, or dans ton code  updatePosition() n'est appelé que dans le constructor, donc avant  MapsIndoors.setPositionProvider(positionProvider), donc le sdk n'a jamais conscience d'avoir une position.

Si la route est bien positionnée, c'est parce que le register de ton propre listener le trigger immédiatement avec la valeur stockée coté JS dans ton Provider.

Il s'agit donc surtout d'un problème lié au mode position simulée.